### PR TITLE
Fix delete url internal server error

### DIFF
--- a/app/api/admin/urls/[shortCode]/route.js
+++ b/app/api/admin/urls/[shortCode]/route.js
@@ -151,7 +151,6 @@ export async function DELETE(request, { params }) {
     await connectDB();
 
     const { shortCode } = params; // ✅ must match folder name
-    console.log("Deleted URL:", deletedUrl);
     console.log("shortCode param received:", shortCode)
     if (!shortCode) {
       return NextResponse.json(

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,7 +3,7 @@ User-agent: *
 Allow: /
 
 # Host
-Host: http://localhost:3000
+Host: https://url-shorter-cyan.vercel.app
 
 # Sitemaps
-Sitemap: http://localhost:3000/sitemap.xml
+Sitemap: https://url-shorter-cyan.vercel.app/sitemap.xml

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>http://localhost:3000/robots.txt</loc><lastmod>2025-08-18T05:55:26.174Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000/sitemap.xml</loc><lastmod>2025-08-18T05:55:26.176Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000/shorten</loc><lastmod>2025-08-18T05:55:26.176Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000/admin</loc><lastmod>2025-08-18T05:55:26.176Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000</loc><lastmod>2025-08-18T05:55:26.176Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://url-shorter-cyan.vercel.app/robots.txt</loc><lastmod>2025-08-22T09:44:05.025Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://url-shorter-cyan.vercel.app/sitemap.xml</loc><lastmod>2025-08-22T09:44:05.025Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://url-shorter-cyan.vercel.app/admin</loc><lastmod>2025-08-22T09:44:05.025Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://url-shorter-cyan.vercel.app</loc><lastmod>2025-08-22T09:44:05.025Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://url-shorter-cyan.vercel.app/shorten</loc><lastmod>2025-08-22T09:44:05.025Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<sitemap><loc>http://localhost:3000/sitemap-0.xml</loc></sitemap>
+<sitemap><loc>https://url-shorter-cyan.vercel.app/sitemap-0.xml</loc></sitemap>
 </sitemapindex>


### PR DESCRIPTION
Fix 500 Internal Server Error on URL deletion by removing premature log statement.

The DELETE API handler was throwing a `ReferenceError` because it attempted to log the `deletedUrl` variable before it was assigned a value, leading to a 500 error response.

---
<a href="https://cursor.com/background-agent?bcId=bc-b98ec082-8f31-4a0f-b32e-b838866df49a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b98ec082-8f31-4a0f-b32e-b838866df49a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

